### PR TITLE
Fix contact_key not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1249,7 +1249,7 @@ async function resetGroupCache(group_id) {
       logger.debug("removed group from cache:", group_key);
     }
     catch (error) {
-      console.error("An error occurred getting redis:", contact_key);
+      console.error("An error occurred getting redis:", error);
     }
   }
 }


### PR DESCRIPTION
This bug prevents routing operations when a redis db is not correctly configured. Exception of contact_key not defined is raised.